### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ ath10k-firmware
 
 These are the latest firmware files for ath10k, a mac80211 driver for
 QCA988x, QCA6174, QCA99XX and similar. The official location to
-download ath10k images is from linux-firmware:
+download ath10k images is from linux-firmware (it may contain an older version):
+
 
 https://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git/
 


### PR DESCRIPTION
According to https://wireless.wiki.kernel.org/en/users/Drivers/ath10k/firmware this repo (https://github.com/kvalo/ath10k-firmware/) is the source url for the firmware and indeed, kernel.org has older firmwares, so just making this a bit clearer