### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ https://git.kernel.org/cgit/linux/kernel/git/firmware/linux-firmware.git/
 
 For more information check the wiki:
 
-http://wireless.kernel.org/en/users/Drivers/ath10k/firmware
+http://wireless.wiki.kernel.org/en/users/Drivers/ath10k/firmware
 
 


### PR DESCRIPTION
Link to the wiki leads to bad certificate error. From the certificate itself I know that there is `wiki` missing in the subdomains.